### PR TITLE
Remove source activation, add next steps message

### DIFF
--- a/quickstart.sh
+++ b/quickstart.sh
@@ -180,9 +180,8 @@ else
     show_spinner $! "Installing PyTorch (CPU)..."
 fi
 
-# Install HuggingFace with compatible versions
-# Pin transformers to 4.46.3 to avoid tie_weights incompatibility with custom models
-( uv pip install --python standard_model transformers==4.46.3 > /dev/null 2>&1 ) &
+# Install HuggingFace libraries
+( uv pip install --python standard_model transformers > /dev/null 2>&1 ) &
 show_spinner $! "Installing HuggingFace transformers..."
 
 ( uv pip install --python standard_model datasets > /dev/null 2>&1 ) &


### PR DESCRIPTION
The source command doesn't work when run via bash -c since it activates in a subshell that exits. Instead, print instructions for the user to manually activate.